### PR TITLE
Overview scene fetches data from backend

### DIFF
--- a/scenes/login.js
+++ b/scenes/login.js
@@ -50,7 +50,7 @@ export default class LoginForm extends Component {
   }
 
   submitToServer() {
-    fetch('http://138.68.56.236:3000/api/login', {
+    fetch('http://138.68.56.236:3000/login', {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/scenes/overview.js
+++ b/scenes/overview.js
@@ -25,22 +25,16 @@ export default class Overview extends Component {
   }
 
   componentDidMount() {
-    let email = 'test@apu.edu';// (this.props.email) ? this.props.email : null;
+    let email = (this.props.email) ? this.props.email : null;
     // let now = new Date();
     // let hourAgo = new Date();
     // hourAgo.setHours(hourAgo.getHours()-1);
-    fetch('http://138.68.56.236:3000/getUsageEvent', {
+    fetch(`http://138.68.56.236:3000/getUsageEvent?email=${encodeURI(email)}`, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        // meter: 0,
-        // startDate: hourAgo,
-        // endDate: now,
-        email
-      })
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
     })
     .then((response) => response.text())
     .then((responseText) => {

--- a/scenes/overview.js
+++ b/scenes/overview.js
@@ -25,20 +25,21 @@ export default class Overview extends Component {
   }
 
   componentDidMount() {
-    let now = new Date();
-    let hourAgo = new Date();
-    hourAgo.setHours(hourAgo.getHours()-1);
-    // TODO: Set this URL to the actual API location - 'data' is just a placeholder
-    fetch('http://138.68.56.236:3000/api/data', {
+    let email = 'test@apu.edu';// (this.props.email) ? this.props.email : null;
+    // let now = new Date();
+    // let hourAgo = new Date();
+    // hourAgo.setHours(hourAgo.getHours()-1);
+    fetch('http://138.68.56.236:3000/getUsageEvent', {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        meter: 0,
-        startDate: hourAgo,
-        endDate: now
+        // meter: 0,
+        // startDate: hourAgo,
+        // endDate: now,
+        email
       })
     })
     .then((response) => response.text())

--- a/scenes/overview.js
+++ b/scenes/overview.js
@@ -20,16 +20,38 @@ export default class Overview extends Component {
     super(props);
     // Initialize state variables 
     this.state = {
-      
+      data: ''
     }
-    
-    // Bind functions to instance
+  }
+
+  componentDidMount() {
+    let now = new Date();
+    let hourAgo = new Date();
+    hourAgo.setHours(hourAgo.getHours()-1);
+    // TODO: Set this URL to the actual API location - 'data' is just a placeholder
+    fetch('http://138.68.56.236:3000/api/data', {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        meter: 0,
+        startDate: hourAgo,
+        endDate: now
+      })
+    })
+    .then((response) => response.text())
+    .then((responseText) => {
+      this.setState({ data: responseText });
+    });
   }
 
   render() {
     return (
       <View style={styles.container}>
         <Text>{this.props.message}</Text>
+        <Text>{this.state.data}</Text>
       </View>
     )
   }

--- a/scenes/register.js
+++ b/scenes/register.js
@@ -71,6 +71,7 @@ export default class Register extends Component {
           placeholderTextColor="rgba(255,255,255,0.5)"
           autoCapitalize="none"
           returnKeyType="next"
+          secureTextEntry={true}
           onChangeText={(text) => this.verifyInput('password', text)}
         />
         <TextInput style={[styles.field, !this.state.fieldValidities[4] && styles.invalid]}
@@ -79,6 +80,7 @@ export default class Register extends Component {
           placeholderTextColor="rgba(255,255,255,0.5)"
           autoCapitalize="none"
           returnKeyType="next"
+          secureTextEntry={true}
           onChangeText={(text) => this.verifyInput('passwordVerification', text)}
         />
         <TextInput style={[styles.field, !this.state.fieldValidities[5] && styles.invalid]}
@@ -158,7 +160,7 @@ export default class Register extends Component {
   }
 
   submitRegistration() {
-    fetch('http://138.68.56.236:3000/api/newUser', {
+    fetch('http://138.68.56.236:3000/newUser', {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -185,7 +187,7 @@ export default class Register extends Component {
   }
 
   submitLogin() {
-    fetch('http://138.68.56.236:3000/api/login', {
+    fetch('http://138.68.56.236:3000/login', {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/scenes/splash.js
+++ b/scenes/splash.js
@@ -48,7 +48,13 @@ export default class Splash extends Component {
   loadUserData(userObject) {
     // Do stuff with user data
     // Load the next scene
-    this.props.navigator.push({ name: 'overview', passProps: { message: JSON.stringify(userObject) } });
+    this.props.navigator.push({
+      name: 'overview',
+      passProps: {
+        message: JSON.stringify(userObject),
+        email: userObject.email
+      }
+    });
   }
 
   loadLoginForm() {


### PR DESCRIPTION
Basic logic in place for the overview scene to fetch data (for now using a test email address) from the backend server and display it on-screen.

Also updates fetch URLs across the app to fit the backend's new URL scheme in which `/api/` is only included for protected areas of the backend (i.e. not login & register)