### PR TITLE
Store login info globally instead of passing props

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -5,7 +5,8 @@ import React, { Component } from 'react';
 import {
   AppRegistry,
   StyleSheet,
-  Navigator
+  Navigator,
+  Text
 } from 'react-native';
 
 import Settings from './scenes/settings';
@@ -17,29 +18,40 @@ import Register from './scenes/register';
 import Overview from './scenes/overview';
 
 export default class FlowApp extends Component {
+
   render() {
     return (
       <Navigator
-        initialRoute={{ title: 'Flow', name: 'splash' }}
+        initialRoute={{ name: 'splash' }}
+        configureScene={(route) => route.sceneConfig || Navigator.SceneConfigs.FloatFromBottom}
         renderScene={(route, navigator) => {
+          let scene = <Text>Bad route name given!</Text>;
+
           switch (route.name) {
             case 'splash':
-              return <Splash navigator={navigator} />;
+              scene = <Splash pushRoute={navigator.push} />;
+              break;
             case 'login':
-              return <Login {...route.passProps} />;
+              scene = <Login pushRoute={navigator.push} {...route.passProps} />;
+              break;
             case 'register':
-              return <Register {...route.passProps} />;
+              scene = <Register pushRoute={navigator.push} {...route.passProps} />;
+              break;
             case 'settings':
-              return <Settings {...route.passsProps} />;
+              scene = <Settings {...route.passsProps} />;
+              break;
             case 'changeAccount':
-              return <ChangeAccount {...route.passProps} />;
+              scene = <ChangeAccount {...route.passProps} />;
+              break;
             case 'meters':
-              return <Meters {...route.passProps} />;
+              scene = <Meters {...route.passProps} />;
+              break;
             case 'overview':
-              return <Overview navigator={navigator} {...route.passProps} />;
-            default:
-              return <Text>Bad route name given!</Text>
+              scene = <Overview {...route.passProps} />;
+              break;
           }
+
+          return scene;
         }}
       />
     );

--- a/scenes/login.js
+++ b/scenes/login.js
@@ -2,7 +2,7 @@
 // Flow
 
 import React, { Component } from 'react';
-import { View, StyleSheet, TextInput, Text, TouchableHighlight } from 'react-native';
+import { AsyncStorage, View, StyleSheet, TextInput, Text, TouchableHighlight } from 'react-native';
 
 export default class LoginForm extends Component {
 
@@ -66,17 +66,17 @@ export default class LoginForm extends Component {
       })
     })    
     .then((response) => response.json())
-    .then((responseObject) => {
+    .then(async (responseObject) => {
       if (responseObject.message === 'ok' && typeof responseObject.token === 'string') {
         this.setState({ submitReport: '' });
-        this.props.pushRoute({
-          name: 'overview',
-          passProps: {
-            message: JSON.stringify(responseObject),
-            email: responseObject.email,
-            token: responseObject.token
-          }
-        });
+        
+        try {
+          await AsyncStorage.multiSet([['email', responseObject.email], ['token', responseObject.token]]);
+        } catch(error) {
+          console.error(error);
+        }
+
+        this.props.pushRoute({ name: 'overview', passProps: {message: JSON.stringify(responseObject)} });
       }
       else if (responseObject.message === 'lol nice tri n00b') {
         // Thank you George for that wonderful masterpiece, that piece of art of a server response

--- a/scenes/overview.js
+++ b/scenes/overview.js
@@ -2,42 +2,46 @@
 // Flow
 
 import React, { Component } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { AsyncStorage, StyleSheet, View, Text } from 'react-native';
 
 export default class Overview extends Component {
   
   static get defaultProps() {
     return {
-      message: 'Default message',
-      email: '',
-      token: ''
+      message: 'Default message'
     };
   }
 
   constructor(props) {
     super(props);
-    // Initialize state variables 
+    // Initialize state variables
     this.state = {
       data: ''
     }
   }
 
   componentDidMount() {
-    let email = (this.props.email) ? this.props.email : null;
-    // let now = new Date();
-    // let hourAgo = new Date();
-    // hourAgo.setHours(hourAgo.getHours()-1);
-    fetch(`http://138.68.56.236:3000/api/getUsageEvent?email=${encodeURI(email)}`, {
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'x-access-token': this.props.token
+    AsyncStorage.multiGet(['email', 'token'], (errors, results) => {
+      if (errors) {
+        console.error(errors);
       }
-    })
-    .then((response) => response.text())
-    .then((responseText) => {
-      this.setState({ data: responseText });
+      let email = results[0][1];
+      let token = results[1][1];
+      // let now = new Date();
+      // let hourAgo = new Date();
+      // hourAgo.setHours(hourAgo.getHours()-1);
+      fetch(`http://138.68.56.236:3000/api/getUsageEvent?email=${encodeURI(email)}`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'x-access-token': token
+        }
+      })
+      .then((response) => response.text())
+      .then((responseText) => {
+        this.setState({ data: responseText });
+      });
     });
   }
 

--- a/scenes/register.js
+++ b/scenes/register.js
@@ -202,7 +202,7 @@ export default class Register extends Component {
       })
     })    
     .then((response) => response.json())
-    .then((responseObject) => {
+    .then(async (responseObject) => {
       if (typeof responseObject.token === 'string') {
         this.setState({ submitReport: '' });
         

--- a/scenes/register.js
+++ b/scenes/register.js
@@ -2,7 +2,7 @@
 // Flow
 
 import React, { Component } from 'react';
-import { StyleSheet, TextInput, Text, TouchableHighlight } from 'react-native';
+import { AsyncStorage, StyleSheet, TextInput, Text, TouchableHighlight } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 export default class Register extends Component {
@@ -205,14 +205,14 @@ export default class Register extends Component {
     .then((responseObject) => {
       if (typeof responseObject.token === 'string') {
         this.setState({ submitReport: '' });
-        this.props.pushRoute({
-          name: 'overview',
-          passProps: {
-            message: JSON.stringify(responseObject),
-            email: responseObject.email,
-            token: responseObject.token
-          }
-        });
+        
+        try {
+          await AsyncStorage.multiSet([['email', responseObject.email], ['token', responseObject.token]]);
+        } catch(error) {
+          console.error(error);
+        }
+
+        this.props.pushRoute({ name: 'overview', passProps: {message: JSON.stringify(responseObject)} });
       }
       else
         this.setState({ submitReport: 'Login failed; bad username or password.' });


### PR DESCRIPTION
Now, after a login or register, instead of merely passing the email and token to the Overview scene as a prop, the email and token are stored into globally accessable app storage via React Native's AsyncStorage API. They are then retrieved from AsyncStorage by the Overview scene. This means the Overview scene will be able to get that data even when navigated to via the drawer or other non-login methods.